### PR TITLE
Refresh portfolio content and styling

### DIFF
--- a/src/components/FAQ.jsx
+++ b/src/components/FAQ.jsx
@@ -1,5 +1,37 @@
+import '../styles/FAQ.css';
+
+const faqs = [
+  {
+    question: 'どんなプロジェクトにフィットしますか？',
+    answer:
+      'RAGやAIエージェントなど、LLMを活用した業務改善・新規サービス構築が得意領域です。要件定義から実装、運用設計まで一気通貫でリードできます。'
+  },
+  {
+    question: '海外メンバーとの開発体制は可能ですか？',
+    answer:
+      'はい。インド拠点を含むグローバルチームでのプロジェクトマネジメント経験があり、英語でのタスク調整やレビュー体制の構築に慣れています。'
+  },
+  {
+    question: '導入後の改善や運用もサポートしてもらえますか？',
+    answer:
+      'セキュリティ対応やMLOps設計、KPIモニタリングを含めて伴走が可能です。継続的な改善サイクルを前提にした体制づくりを重視しています。'
+  }
+];
+
 function FAQ() {
-    return <div>FAQ content</div>;
+  return (
+    <section className="faq">
+      <div className="section-title">FAQ</div>
+      <div className="faq__list">
+        {faqs.map((faq) => (
+          <article className="faq-item" key={faq.question}>
+            <h3>{faq.question}</h3>
+            <p>{faq.answer}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
 }
-// ContactとFAQも同様に作成
+
 export default FAQ;

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,11 +1,18 @@
 import "../styles/App.css";
 import "../styles/Home.css";
+
 function Home() {
     return (
-        <div className= "intro">
-            <div className="name_first">Keiichi</div>
-            <div className="name_second">Hayashi</div>
-        </div>
+        <section className="intro">
+            <div className="intro__name">
+                <div className="name_first">Keiichi</div>
+                <div className="name_second">Hayashi</div>
+            </div>
+            <p className="intro__role">Engineer / Project Manager</p>
+            <p className="intro__statement">
+                RAGを中心にAIプロダクトの戦略・設計・実装をリードし、グローバルチームとともに"動く"体験を届けます。
+            </p>
+        </section>
     );
 }
 

--- a/src/components/Info.jsx
+++ b/src/components/Info.jsx
@@ -1,25 +1,206 @@
-import React from 'react'
-import hiyoshi from '../img/hiyoshi_image.JPG'
-import '../styles/Info.css'
-import tree from '../img/tree_image.PNG';
-import spiderVideo from '../img/marching-spider.MP4';
-import windmilVideo from '../img/windmil_animation.mp4';
+import '../styles/Info.css';
+
+const experiences = [
+  {
+    title: 'Machine Learning Engineer',
+    subtitle: 'RAG / QA Automation / AI Platforming',
+    bullets: [
+      'Retrieval-Augmented Generation（RAG）基盤の設計・実装を主導し、資料検索からQAチャットボットまでを一貫して構築。',
+      'Ark ETL / Ark RAG を活用したクライアント案件に参画し、ドキュメントレビュー効率化と業務ナレッジ活用を推進。',
+      'IP制限やAzure AD連携など、エンタープライズ向けセキュリティ要件に対応したデプロイをリード。'
+    ]
+  },
+  {
+    title: 'Project Manager',
+    subtitle: 'Global Delivery / Stakeholder Enablement',
+    bullets: [
+      '多国籍メンバーとのリモートコラボレーションを英語でリードし、仕様定義からリリースまでの全体進行を可視化。',
+      'タスクの優先順位付けとスプリント計画を担い、リソース配分とスケジュールの最適化を実現。',
+      'クライアント折衝を通じて要件を抽出し、AI導入のROIとリスクをバランスさせた意思決定を支援。'
+    ]
+  }
+];
+
+const skillGroups = [
+  {
+    category: 'Programming',
+    items: ['Python', 'JavaScript / TypeScript', 'React / Next.js', 'C++（Learning）', 'Flutter（Learning）']
+  },
+  {
+    category: 'AI / Machine Learning',
+    items: ['LangChain', 'RAG on Pinecone & Azure AI Search', 'GPT / Gemini / Cohere', 'RLHF & Evolutionary Algorithms', 'Computer Vision（Viola-Jones, CNN, Decision Tree）']
+  },
+  {
+    category: 'Cloud / Infrastructure',
+    items: ['AWS（EC2, Lambda, RDS, S3, Cognito, ECS, VPC）', 'Azure（App Service, Blob Storage, AI Search, AD連携）', 'Docker & Kubernetes', 'Prisma / PostgreSQL']
+  },
+  {
+    category: 'Dev Environment',
+    items: ['MacBook Pro', 'NeoVim', 'Fish Shell', 'GitHub', 'Docker Compose']
+  }
+];
+
+const projects = [
+  {
+    name: 'CHAPPY',
+    description: 'AIコンパニオンアプリ。会話ログからペルソナとメモリを生成し、Firestore・PostgreSQL・Pineconeを連携させた長期記憶体験を設計。モバイルUI/UXもフルリード。',
+    tech: 'Flutter / Firebase / PostgreSQL / Pinecone'
+  },
+  {
+    name: 'Timey',
+    description: 'Google Calendar × AgentCore × AWS Bedrockで動作するAIスケジューラー。自動スケジュール提案やバッファ挿入を行い、日々の予定調整を自律化。',
+    tech: 'GAS / AgentCore / Amazon Bedrock'
+  },
+  {
+    name: '広告画像自動生成システム',
+    description: 'Adobe Illustratorを自動制御し、AIで生成したコピーや配色をもとに広告素材を量産。制作オペレーションのボトルネックを解消。',
+    tech: 'Illustrator Scripting / Generative AI'
+  },
+  {
+    name: '音声対話システム',
+    description: '5歳児向けに音声で対話するチャットボット。Whisperで音声認識し、Style BERTとLLMを組み合わせた応答をCoefont/Voiceboxで読み上げ、AWS上で運用。',
+    tech: 'OpenAI Whisper / Style BERT / AWS'
+  }
+];
+
+const hackathons = [
+  {
+    title: 'No-Code/Low-Code AI Hackathon in San Francisco 2025',
+    date: '2025.05.21-24 / San Francisco',
+    award: '3位入賞',
+    host: '主催: Aparavi 他 / 協賛: Google, Neo4j など',
+    summary: 'Low-Code/No-Codeを駆使したB2B向けAIツールのプロトタイプを4日間で開発。多様な企業スポンサーの期待に応える機能を実装。'
+  },
+  {
+    title: 'AWS AI Agent 1Day Hackathon',
+    date: '2025.09.15 / Tokyo',
+    award: '優勝',
+    host: '主催: MeltingHack / AWS Startup Loft Tokyo',
+    summary: 'Amazon Bedrock AgentCoreを用い、AI Agent Marketplace向けのエージェントを1日で構築。バイリンガル開催でのプレゼンテーションも担当。'
+  }
+];
+
+const researchAreas = [
+  '多文化共生とコミュニティデザイン',
+  '日本の財政社会学 × AI活用',
+  '強化学習・進化アルゴリズム',
+  'Robotics × AI',
+  '統計学・金融（株式市場分析）'
+];
+
+const strengths = [
+  'AI / 機械学習 × インフラ × プロジェクトマネジメントのハイブリッドスキル。',
+  'RAGやLLMの実装経験を活かした、課題解決志向のプロダクト思考。',
+  'グローバルチームでの英語コミュニケーションと迅速な意思決定。',
+  'UI/UXのディレクションから設計・実装まで横断できるデザインセンス。'
+];
 
 const Info = () => {
   return (
-    <div>
-      <div className='image-container'>
-        <img src= {hiyoshi} className = 'image_hiyoshi' alt="hiyoshi"/>
-        <img src= {tree} className ='image_hiyoshi' alt='tree'/>
-        <video src={spiderVideo} width="300" loop autoPlay muted playsInline className='video_spider'>
-          Your browser does not support video tag.
-        </video>
-        <video src={windmilVideo} width="300" loop autoPlay muted className='video_spider' playsInline>
-          Your browser does not support video tag.
-        </video>
-      </div>
-    </div>
-  )
-}
+    <section className="info">
+      <div className="info__inner">
+        <header className="info__header">
+          <p className="info__eyebrow">Portfolio Overview</p>
+          <h2 className="info__title">AIプロダクトを"動くところまで"届ける、ハイブリッドエンジニア。</h2>
+          <p className="info__summary">
+            慶應義塾大学経済学部を休学し、RAGやAIエージェントを軸にしたプロジェクトをリード。要件設計からMLOps、
+            UI/UXまでを横断しながら、クライアントやチームの意思決定を支援します。
+          </p>
+          <div className="info__facts">
+            <span className="info-chip">Engineer / Project Manager</span>
+            <span className="info-chip">Focus: RAG &amp; AI Agents</span>
+            <span className="info-chip">Global Team Collaboration</span>
+            <span className="info-chip">慶應義塾大学 経済学部（休学中）</span>
+          </div>
+        </header>
 
-export default Info
+        <div className="info__grid">
+          <section className="info-card info-card--wide">
+            <h3 className="info-card__heading">Professional Experience</h3>
+            <div className="experience-grid">
+              {experiences.map((experience) => (
+                <article className="experience-card" key={experience.title}>
+                  <h4 className="experience-card__title">{experience.title}</h4>
+                  <p className="experience-card__subtitle">{experience.subtitle}</p>
+                  <ul className="info-list">
+                    {experience.bullets.map((bullet, index) => (
+                      <li key={index}>{bullet}</li>
+                    ))}
+                  </ul>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="info-card info-card--wide">
+            <h3 className="info-card__heading">Signature Projects</h3>
+            <div className="info-projects-grid">
+              {projects.map((project) => (
+                <article className="info-project-card" key={project.name}>
+                  <div className="info-project-card__header">
+                    <h4>{project.name}</h4>
+                  </div>
+                  <p className="info-project-card__description">{project.description}</p>
+                  <p className="info-project-card__tech">{project.tech}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="info-card">
+            <h3 className="info-card__heading">Skill Matrix</h3>
+            <div className="skill-groups">
+              {skillGroups.map((group) => (
+                <div className="skill-group" key={group.category}>
+                  <p className="skill-group__title">{group.category}</p>
+                  <div className="skill-group__chips">
+                    {group.items.map((item) => (
+                      <span className="skill-chip" key={item}>{item}</span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="info-card">
+            <h3 className="info-card__heading">Research &amp; Curiosity</h3>
+            <ul className="info-list">
+              {researchAreas.map((area) => (
+                <li key={area}>{area}</li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="info-card">
+            <h3 className="info-card__heading">Strengths</h3>
+            <ul className="info-list">
+              {strengths.map((strength) => (
+                <li key={strength}>{strength}</li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="info-card info-card--wide">
+            <h3 className="info-card__heading">Hackathon Highlights</h3>
+            <div className="hackathon-list">
+              {hackathons.map((hackathon) => (
+                <article className="hackathon-card" key={hackathon.title}>
+                  <div className="hackathon-card__header">
+                    <p className="hackathon-card__date">{hackathon.date}</p>
+                    <span className="info-chip info-chip--accent">{hackathon.award}</span>
+                  </div>
+                  <h4 className="hackathon-card__title">{hackathon.title}</h4>
+                  <p className="hackathon-card__host">{hackathon.host}</p>
+                  <p className="hackathon-card__summary">{hackathon.summary}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Info;

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,21 +1,78 @@
 'use client';
 import { Canvas } from '@react-three/fiber';
+import { Environment } from '@react-three/drei';
 import '../styles/Projects.css';
 import Model from './Model.jsx';
-import { Environment } from '@react-three/drei';
+
+const projectList = [
+  {
+    name: 'CHAPPY',
+    label: 'AIコンパニオンアプリ',
+    description:
+      'メモリとペルソナを備えたチャット体験を設計。Firestore / PostgreSQL / Pineconeを横断しながら、モバイルUIまでワンストップでデリバリー。',
+    highlights: ['長期記憶とペルソナ同期', '体験設計〜実装をフルリード'],
+    stack: 'Flutter / Firebase / PostgreSQL / Pinecone'
+  },
+  {
+    name: 'Timey',
+    label: 'AI Calendar Assistant',
+    description:
+      'AgentCoreとAWS Bedrockを連携させたスケジュール自動化エージェント。Google Calendarと同期し、提案・調整・バッファ確保まで自律実行。',
+    highlights: ['Agent Orchestration', 'GASとの連携'],
+    stack: 'Google Apps Script / AgentCore / Amazon Bedrock'
+  },
+  {
+    name: '広告画像自動生成システム',
+    label: 'Creative Automation',
+    description:
+      'Adobe Illustratorを自動制御し、AI生成コピー＆配色で広告素材を高速生成。制作ワークフローのボトルネックを解消。',
+    highlights: ['生成AI × DTP自動化', '制作リードタイム短縮'],
+    stack: 'Illustrator Scripting / Generative AI'
+  },
+  {
+    name: '音声対話システム',
+    label: 'Voice Conversational Bot',
+    description:
+      '5歳児向け音声チャットボット。Whisper × Style BERT × LLMで自然な応答を生成し、Coefont / Voiceboxでリアルタイム読み上げ。',
+    highlights: ['Child-friendly UX', 'AWSフルマネージド運用'],
+    stack: 'OpenAI Whisper / Style BERT / AWS'
+  }
+];
 
 function Projects() {
-    return <div className='projects'>
-    <div className='section-title'>Projects</div>
-    <>
-      <div className='canvas-container'>
-        <Canvas>
-          <directionalLight intensity={3} position={[0, 3, 2]} />
-          <Environment preset='city' />
-          <Model />
-        </Canvas>
+  return (
+    <section className="projects">
+      <div className="section-title">Projects</div>
+      <div className="projects__grid">
+        <div className="canvas-container">
+          <Canvas>
+            <directionalLight intensity={3} position={[0, 3, 2]} />
+            <Environment preset="city" />
+            <Model />
+          </Canvas>
+        </div>
+        <div className="projects__list">
+          {projectList.map((project) => (
+            <article className="project-card" key={project.name}>
+              <div className="project-card__header">
+                <h3>{project.name}</h3>
+                <span className="project-card__label">{project.label}</span>
+              </div>
+              <p className="project-card__description">{project.description}</p>
+              <div className="project-card__badges">
+                {project.highlights.map((highlight) => (
+                  <span className="project-badge" key={highlight}>
+                    {highlight}
+                  </span>
+                ))}
+              </div>
+              <p className="project-card__stack">{project.stack}</p>
+            </article>
+          ))}
+        </div>
       </div>
-    </>
-  </div>;
+    </section>
+  );
 }
+
 export default Projects;

--- a/src/styles/FAQ.css
+++ b/src/styles/FAQ.css
@@ -1,0 +1,49 @@
+.faq {
+  padding: 100px 5% 120px;
+  background: #03070c;
+  color: #f2e8df;
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.faq__list {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.faq-item {
+  background: rgba(9, 23, 38, 0.7);
+  border-radius: 22px;
+  padding: 28px;
+  border: 1px solid rgba(82, 82, 89, 0.45);
+  backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 20px 40px rgba(3, 7, 12, 0.4);
+}
+
+.faq-item h3 {
+  margin: 0;
+  font-family: 'Neue Montreal Medium';
+  font-size: 1.05rem;
+}
+
+.faq-item p {
+  margin: 0;
+  line-height: 1.7;
+  color: rgba(242, 232, 223, 0.85);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .faq {
+    padding: 80px 6% 100px;
+  }
+
+  .faq-item {
+    padding: 24px;
+  }
+}

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -1,23 +1,54 @@
 .name_first {
   font-family: "Tusker Grotesk 1800 Super";
-  font-size: 200px;
+  font-size: clamp(4.5rem, 12vw, 12.5rem);
   text-transform: uppercase;
   padding-bottom: 0;
-  padding-top: 50px ;
+  padding-top: 20px;
   color: #f2e8df;
-  line-height: 1.05;
+  line-height: 1.02;
 }
 
 .name_second {
   font-family: "Tusker Grotesk 1800 Super";
   padding-top: 0;
-  font-size: 200px;
+  font-size: clamp(4.5rem, 12vw, 12.5rem);
   text-transform: uppercase;
   color: #f2e8df;
-  line-height: 1.05;
+  line-height: 1.02;
 }
 
 .intro {
-  background-color: #03070C;
-  padding: 60px 5% 0px 5%;
+  background: linear-gradient(135deg, #03070c 0%, rgba(3, 7, 12, 0.9) 35%, rgba(9, 23, 38, 0.75) 100%);
+  padding: 80px 5% 60px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.intro__name {
+  display: flex;
+  flex-direction: column;
+}
+
+.intro__role {
+  font-family: "Neue Montreal Medium";
+  font-size: clamp(1.1rem, 2.2vw, 1.4rem);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(207, 242, 80, 0.85);
+  margin: 0;
+}
+
+.intro__statement {
+  max-width: 680px;
+  line-height: 1.8;
+  color: rgba(242, 232, 223, 0.85);
+  font-size: clamp(1rem, 2vw, 1.1rem);
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .intro {
+    padding: 70px 6% 56px;
+  }
 }

--- a/src/styles/Info.css
+++ b/src/styles/Info.css
@@ -1,12 +1,293 @@
-.image_hiyoshi {
-  width: 100%;
-  z-index: 300;
+.info {
+  padding: 120px 5% 140px;
+  background: radial-gradient(circle at top right, rgba(207, 242, 80, 0.12), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(82, 82, 89, 0.2), transparent 60%),
+    #03070c;
+  color: #f2e8df;
 }
 
-.video_spider {
-  width: 100%;
+.info__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 72px;
 }
 
-.image-container {
-  padding: 0px 5% 0px 5%;
+.info__header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.info__eyebrow {
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: rgba(207, 242, 80, 0.8);
+  margin: 0;
+}
+
+.info__title {
+  font-family: 'Neue Montreal Medium';
+  font-size: clamp(2.4rem, 3vw, 3.2rem);
+  line-height: 1.25;
+  margin: 0;
+}
+
+.info__summary {
+  margin: 0;
+  max-width: 760px;
+  line-height: 1.8;
+  font-size: 1rem;
+  color: rgba(242, 232, 223, 0.9);
+}
+
+.info__facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.info-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(207, 242, 80, 0.35);
+  background: rgba(9, 23, 38, 0.7);
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(242, 232, 223, 0.9);
+}
+
+.info-chip--accent {
+  background: rgba(207, 242, 80, 0.18);
+  color: #cff250;
+  border-color: rgba(207, 242, 80, 0.4);
+}
+
+.info__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.info-card {
+  background: rgba(9, 23, 38, 0.68);
+  border: 1px solid rgba(82, 82, 89, 0.45);
+  border-radius: 24px;
+  padding: 32px;
+  box-shadow: 0 24px 48px rgba(3, 7, 12, 0.45);
+  backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.info-card--wide {
+  grid-column: 1 / -1;
+}
+
+.info-card__heading {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(207, 242, 80, 0.85);
+}
+
+.experience-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.experience-card {
+  background: rgba(3, 7, 12, 0.55);
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid rgba(82, 82, 89, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.experience-card__title {
+  margin: 0;
+  font-family: 'Neue Montreal Medium';
+  font-size: 1.1rem;
+}
+
+.experience-card__subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(242, 232, 223, 0.6);
+}
+
+.info-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.info-list li {
+  position: relative;
+  padding-left: 18px;
+  line-height: 1.7;
+  color: rgba(242, 232, 223, 0.9);
+}
+
+.info-list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.6rem;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(207, 242, 80, 0.8);
+}
+
+.skill-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.skill-group__title {
+  margin: 0 0 10px;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(242, 232, 223, 0.65);
+}
+
+.skill-group__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.skill-chip {
+  padding: 8px 14px;
+  border-radius: 12px;
+  background: rgba(82, 82, 89, 0.35);
+  color: rgba(242, 232, 223, 0.92);
+  font-size: 0.85rem;
+  border: 1px solid rgba(82, 82, 89, 0.4);
+}
+
+.info-projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.info-project-card {
+  background: rgba(3, 7, 12, 0.55);
+  border-radius: 18px;
+  padding: 24px;
+  border: 1px solid rgba(82, 82, 89, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.info-project-card__header h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-family: 'Neue Montreal Medium';
+}
+
+.info-project-card__description {
+  margin: 0;
+  line-height: 1.7;
+  color: rgba(242, 232, 223, 0.88);
+  font-size: 0.95rem;
+}
+
+.info-project-card__tech {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(207, 242, 80, 0.75);
+}
+
+.hackathon-list {
+  display: grid;
+  gap: 20px;
+}
+
+.hackathon-card {
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid rgba(82, 82, 89, 0.45);
+  background: rgba(3, 7, 12, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hackathon-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.hackathon-card__date {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(242, 232, 223, 0.6);
+}
+
+.hackathon-card__title {
+  margin: 0;
+  font-family: 'Neue Montreal Medium';
+  font-size: 1.05rem;
+}
+
+.hackathon-card__host,
+.hackathon-card__summary {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(242, 232, 223, 0.85);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .info {
+    padding: 90px 6% 110px;
+  }
+
+  .info-card {
+    padding: 28px;
+  }
+
+  .info-project-card,
+  .experience-card,
+  .hackathon-card {
+    padding: 20px;
+  }
+
+  .info__facts {
+    gap: 8px;
+  }
+
+  .info-chip {
+    font-size: 0.72rem;
+    padding: 8px 14px;
+  }
 }

--- a/src/styles/Projects.css
+++ b/src/styles/Projects.css
@@ -1,14 +1,127 @@
 .projects {
-  font-size: 30px;
-  font-family: 'Neue Montreal Medium';
-  text-decoration: none;
+  padding: 120px 5% 140px;
+  background: #060f18;
   color: #f2e8df;
-  line-height: 1.3;
-  position: relative;
-  padding: 0px 5% 0px 5%;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.projects .section-title {
+  letter-spacing: 0.3em;
+}
+
+.projects__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+  gap: 32px;
+  align-items: stretch;
 }
 
 .canvas-container {
-  margin-bottom: 100px;
-  width: 100%;
+  position: relative;
+  border-radius: 28px;
+  overflow: hidden;
+  border: 1px solid rgba(82, 82, 89, 0.45);
+  background: linear-gradient(160deg, rgba(207, 242, 80, 0.12), rgba(3, 7, 12, 0.9));
+  min-height: 420px;
+}
+
+.canvas-container canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.projects__list {
+  display: grid;
+  gap: 24px;
+}
+
+.project-card {
+  background: rgba(9, 23, 38, 0.72);
+  border-radius: 24px;
+  padding: 28px;
+  border: 1px solid rgba(82, 82, 89, 0.45);
+  backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 24px 48px rgba(3, 7, 12, 0.45);
+}
+
+.project-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.project-card__header h3 {
+  margin: 0;
+  font-family: 'Neue Montreal Medium';
+  font-size: 1.3rem;
+}
+
+.project-card__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(207, 242, 80, 0.75);
+}
+
+.project-card__description {
+  margin: 0;
+  line-height: 1.8;
+  color: rgba(242, 232, 223, 0.9);
+  font-size: 0.98rem;
+}
+
+.project-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.project-badge {
+  display: inline-flex;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(207, 242, 80, 0.18);
+  border: 1px solid rgba(207, 242, 80, 0.35);
+  color: #cff250;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.project-card__stack {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(242, 232, 223, 0.6);
+}
+
+@media (max-width: 1024px) {
+  .projects__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .canvas-container {
+    min-height: 360px;
+  }
+}
+
+@media (max-width: 768px) {
+  .projects {
+    padding: 90px 6% 110px;
+  }
+
+  .project-card {
+    padding: 24px;
+  }
+
+  .project-card__header h3 {
+    font-size: 1.15rem;
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the hero, projects, and info sections to showcase portfolio content such as skills, projects, and hackathon wins
- add FAQ coverage and supporting styles for the new content-rich layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4c773ab8832b8a8491319c1f2cc3